### PR TITLE
Dol/order tracking/fix null order id when refresh page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ function App() {
                 <Route path='/comparison' element={<Comparison/>}/>
                 <Route path='/cart' element={<ProtectedRoute allowedRoles={[Role.User]}><Cart/></ProtectedRoute>}/>
                 <Route path='/purchase' element={<ProtectedRoute allowedRoles={[Role.User]}><Purchase/></ProtectedRoute>}/>
-                <Route path='/order-tracking' element={<ProtectedRoute allowedRoles={[Role.Admin, Role.User]}><OrderTracking/></ProtectedRoute>}/>
+                <Route path='/order/:order_id' element={<ProtectedRoute allowedRoles={[Role.Admin, Role.User]}><OrderTracking/></ProtectedRoute>}/>
                 <Route path='/orders/admin'
                         element={<ProtectedRoute allowedRoles={[Role.Admin]}><AdminOrderList/></ProtectedRoute>}/>
                 <Route path='/orders' element={<ProtectedRoute allowedRoles={[Role.User]}><OrderList/></ProtectedRoute>}/>

--- a/src/api/order/UpdateOrderStatus.ts
+++ b/src/api/order/UpdateOrderStatus.ts
@@ -1,6 +1,6 @@
 import API from "../index.ts";
 
-export const updateOrderStatus = async (id: string | null) => {
+export const updateOrderStatus = async (id: string | undefined) => {
     try {
         const response = await API.put(`/order/status/${id}`);
         return response.data;

--- a/src/api/order/UpdateOrderStatus.ts
+++ b/src/api/order/UpdateOrderStatus.ts
@@ -1,6 +1,6 @@
 import API from "../index.ts";
 
-export const updateOrderStatus = async (id: string) => {
+export const updateOrderStatus = async (id: string | null) => {
     try {
         const response = await API.put(`/order/status/${id}`);
         return response.data;

--- a/src/components/form/UserProfileForm.tsx
+++ b/src/components/form/UserProfileForm.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useState } from "react";
 import {
     Button,
     Card,
@@ -10,14 +11,13 @@ import {
 } from "antd";
 import { EditOutlined } from "@ant-design/icons";
 import { useForm } from "antd/es/form/Form";
+import { motion, AnimatePresence } from "framer-motion";
 import { useToggleEditing } from "../../hook/useToggleEditing.ts";
 import { useFormAutoSync } from "../../hook/useFormAutoSync.ts";
-import "./UserProfileForm.css";
 import { UserGoal, UserTag } from "../../interfaces/UserProfile.ts";
-import React, { useEffect, useState } from "react";
 import { getChangedFields } from "../../helper/formHelper.ts";
 import {checkUserEmailExist} from "../../api/user_profile/CheckUserEmailExists.ts";
-import { motion, AnimatePresence } from "framer-motion";
+import "./UserProfileForm.css";
 
 
 interface UserProfileFormProps {

--- a/src/components/navbar/NavBar.tsx
+++ b/src/components/navbar/NavBar.tsx
@@ -358,7 +358,7 @@ function NavBar() {
                 }
 
                 <div className="absolute right-[40px] space-x-6">
-                    <UserProfile userId={userId} name={name} logout={logout}/>
+                    <UserProfile userId={userId} role={role} name={name} logout={logout}/>
                 </div>
             </div>
             {role === Role.Admin ? <BottomNavBar/> : <></>}

--- a/src/components/navbar/UserProfile.tsx
+++ b/src/components/navbar/UserProfile.tsx
@@ -3,9 +3,10 @@ import {useNavigate} from "react-router-dom";
 import {Avatar, Dropdown} from "antd";
 import {UserOutlined} from "@ant-design/icons";
 import {UserProfileProps} from "../../interfaces/Navbar.ts";
+import { Role } from "../../enum/Role.ts";
 
 
-const UserProfile: React.FC<UserProfileProps> = ({userId, name, logout}) => {
+const UserProfile: React.FC<UserProfileProps> = ({userId, role, name, logout}) => {
     const [menuOpen, setMenuOpen] = useState(false);
     const navigate = useNavigate();
 
@@ -35,7 +36,7 @@ const UserProfile: React.FC<UserProfileProps> = ({userId, name, logout}) => {
                 },
                 {type: "divider" as const},
                 {label: "Profile", key: "profile"},
-                {label: "History", key: "history"},
+                ...(role === Role.User ? [{label: "History", key: "history"}] : []),
                 {label: "Logout", key: "logout"},
             ]),
     ];

--- a/src/interfaces/Navbar.ts
+++ b/src/interfaces/Navbar.ts
@@ -7,6 +7,7 @@ export interface NavItemProps {
 
 export interface UserProfileProps {
     userId: string | null;
+    role: string | null;
     name: string | null;
     logout: () => void;
 }

--- a/src/pages/order_list/AdminOrderList.tsx
+++ b/src/pages/order_list/AdminOrderList.tsx
@@ -234,7 +234,7 @@ function AdminOrderList() {
           bordered
           pagination={{ pageSize: 5 }}
           onRow={(record) => ({
-            onClick: () => navigate(`/order-tracking`, { state: record.id }),
+            onClick: () => navigate(`/order-tracking/?order_id=${record.id}`),
             style: { cursor: "pointer" }
           })}
         />

--- a/src/pages/order_list/AdminOrderList.tsx
+++ b/src/pages/order_list/AdminOrderList.tsx
@@ -234,7 +234,7 @@ function AdminOrderList() {
           bordered
           pagination={{ pageSize: 5 }}
           onRow={(record) => ({
-            onClick: () => navigate(`/order-tracking/?order_id=${record.id}`),
+            onClick: () => navigate(`/order/${record.id}`),
             style: { cursor: "pointer" }
           })}
         />

--- a/src/pages/order_list/OrderList.tsx
+++ b/src/pages/order_list/OrderList.tsx
@@ -161,7 +161,7 @@ function OrderList() {
           bordered
           pagination={{ pageSize: 5 }}
           onRow={(record) => ({
-            onClick: () => navigate(`/order-tracking`, { state: record.id }),
+            onClick: () => navigate(`/order-tracking?order_id=${record.id}`),
             style: { cursor: "pointer" }
           })}
         />

--- a/src/pages/order_list/OrderList.tsx
+++ b/src/pages/order_list/OrderList.tsx
@@ -161,7 +161,7 @@ function OrderList() {
           bordered
           pagination={{ pageSize: 5 }}
           onRow={(record) => ({
-            onClick: () => navigate(`/order-tracking?order_id=${record.id}`),
+            onClick: () => navigate(`/order/${record.id}`),
             style: { cursor: "pointer" }
           })}
         />

--- a/src/pages/tracking/OrderTracking.tsx
+++ b/src/pages/tracking/OrderTracking.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Modal, message, Steps, StepProps } from "antd";
-import { useLocation, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useAuth } from "../../hook/UseAuth.ts";
 import { RiFileList2Line, RiTruckLine } from "react-icons/ri";
 import { MdOutlinePaid } from "react-icons/md";
@@ -30,8 +30,6 @@ function OrderTracking() {
   const [received, setReceived] = useState<boolean>(true);
   const [adminReceived, setAdminReceived] = useState<boolean>(true);
   const [searchParams, setSearchParams] = useSearchParams();
-  const location = useLocation();
-  // const orderID = location.state;
   const orderID = searchParams.get("order_id");
   const currentStatusIndex = statusMap[orderDetail?.order_status || ""] ?? -1;
   const { role } = useAuth();
@@ -111,7 +109,7 @@ const detail = async (id: string) => {
 };
 
 
-  const updateStatus = (id: string) => {
+  const updateStatus = (id: string | null) => {
     updateOrderStatus(id)
       .then((response) => {
         setIsShowModal(false);

--- a/src/pages/tracking/OrderTracking.tsx
+++ b/src/pages/tracking/OrderTracking.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Modal, message, Steps, StepProps } from "antd";
-import { useSearchParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useAuth } from "../../hook/UseAuth.ts";
 import { RiFileList2Line, RiTruckLine } from "react-icons/ri";
 import { MdOutlinePaid } from "react-icons/md";
@@ -29,8 +29,8 @@ function OrderTracking() {
 //   const [showReceivedButton, setShowReceiveButton] = useState<boolean>(false);
   const [received, setReceived] = useState<boolean>(true);
   const [adminReceived, setAdminReceived] = useState<boolean>(true);
-  const [searchParams, setSearchParams] = useSearchParams();
-  const orderID = searchParams.get("order_id");
+  const { order_id } = useParams();
+  console.log(order_id);
   const currentStatusIndex = statusMap[orderDetail?.order_status || ""] ?? -1;
   const { role } = useAuth();
   const stepItems: StepProps[] = [
@@ -84,9 +84,9 @@ function OrderTracking() {
 
 const detail = async (id: string) => {
   try {
-    const newParams = new URLSearchParams(searchParams);
-    newParams.set("order_id", id);
-    setSearchParams(newParams);
+    // const newParams = new URLSearchParams(searchParams);
+    // newParams.set("order_id", id);
+    // setSearchParams(newParams);
 
     const response = await getOrderDetail(id);
 
@@ -109,7 +109,7 @@ const detail = async (id: string) => {
 };
 
 
-  const updateStatus = (id: string | null) => {
+  const updateStatus = (id: string | undefined) => {
     updateOrderStatus(id)
       .then((response) => {
         setIsShowModal(false);
@@ -124,8 +124,8 @@ const detail = async (id: string) => {
   
 
   useEffect(() => {
-    if (orderID) {
-      detail(orderID);
+    if (order_id) {
+      detail(order_id);
     }
   }, [adminReceived, received, isShowModal]);
 
@@ -137,7 +137,7 @@ const detail = async (id: string) => {
           <div className="flex items-center space-x-2 bg-[#F2EFEF] rounded-md p-2">
             <div className="flex items-center text-[12px] space-x-2">
               <p className="font-bold">ORDER ID:</p>
-              <p>{orderID}</p>
+              <p>{order_id}</p>
             </div>
             <div>|</div>
             <div className="flex items-center text-[12px] space-x-2">
@@ -152,7 +152,7 @@ const detail = async (id: string) => {
             <div className="h-[68px] bg-[#F2EFEF] rounded-md py-1">
               <button
                 className="text-[14px] text-white bg-[#1890ff] rounded-md px-4 py-2 m-3 float-right"
-                // onClick={() => updateStatus(orderID)}
+                // onClick={() => updateStatus(order_id)}
                 onClick={() => setIsShowModal(true)}
               >
                 Pay Now
@@ -160,7 +160,7 @@ const detail = async (id: string) => {
               <Modal
                 title="This is just a mock up of Promptpay"
                 open={isShowModal}
-                onOk={() => updateStatus(orderID)}
+                onOk={() => updateStatus(order_id)}
                 onCancel={() => setIsShowModal(false)}
               >
                 <div className="flex items-center justify-center">
@@ -176,7 +176,7 @@ const detail = async (id: string) => {
               <button
                 className={`text-[14px] text-white bg-[#53D94F]
                 rounded-md px-4 py-2 m-3 float-right`}
-                onClick={() => updateStatus(orderID)}
+                onClick={() => updateStatus(order_id)}
               >
                 Confirm
               </button>
@@ -190,7 +190,7 @@ const detail = async (id: string) => {
                   className={`text-[14px] text-white ${
                     !received ? "bg-[#53D94F]" : "bg-[#E7E7E7]"
                   } rounded-md px-4 py-2 m-3 float-right`}
-                  onClick={() => updateStatus(orderID)}
+                  onClick={() => updateStatus(order_id)}
                   disabled={received}
                 >
                   Order Received

--- a/src/pages/tracking/OrderTracking.tsx
+++ b/src/pages/tracking/OrderTracking.tsx
@@ -30,7 +30,6 @@ function OrderTracking() {
   const [received, setReceived] = useState<boolean>(true);
   const [adminReceived, setAdminReceived] = useState<boolean>(true);
   const { order_id } = useParams();
-  console.log(order_id);
   const currentStatusIndex = statusMap[orderDetail?.order_status || ""] ?? -1;
   const { role } = useAuth();
   const stepItems: StepProps[] = [
@@ -84,10 +83,6 @@ function OrderTracking() {
 
 const detail = async (id: string) => {
   try {
-    // const newParams = new URLSearchParams(searchParams);
-    // newParams.set("order_id", id);
-    // setSearchParams(newParams);
-
     const response = await getOrderDetail(id);
 
     if (!response) {
@@ -152,7 +147,6 @@ const detail = async (id: string) => {
             <div className="h-[68px] bg-[#F2EFEF] rounded-md py-1">
               <button
                 className="text-[14px] text-white bg-[#1890ff] rounded-md px-4 py-2 m-3 float-right"
-                // onClick={() => updateStatus(order_id)}
                 onClick={() => setIsShowModal(true)}
               >
                 Pay Now
@@ -180,8 +174,6 @@ const detail = async (id: string) => {
               >
                 Confirm
               </button>
-              {/* <Divider></Divider>
-                  <button></button> */}
             </div>
           )}
           {role === Role.User && (

--- a/src/pages/tracking/OrderTracking.tsx
+++ b/src/pages/tracking/OrderTracking.tsx
@@ -31,7 +31,8 @@ function OrderTracking() {
   const [adminReceived, setAdminReceived] = useState<boolean>(true);
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
-  const orderID = location.state;
+  // const orderID = location.state;
+  const orderID = searchParams.get("order_id");
   const currentStatusIndex = statusMap[orderDetail?.order_status || ""] ?? -1;
   const { role } = useAuth();
   const stepItems: StepProps[] = [
@@ -125,7 +126,9 @@ const detail = async (id: string) => {
   
 
   useEffect(() => {
-    detail(orderID);
+    if (orderID) {
+      detail(orderID);
+    }
   }, [adminReceived, received, isShowModal]);
 
   return (


### PR DESCRIPTION
* Fixed order ID equals null on admin and user order tracking pages when refreshing the page.
* Hidden the history option on the dropdown when the user's role is admin.